### PR TITLE
trivy-sbom: pin Docker image

### DIFF
--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -13,7 +13,7 @@ steps:
     - scan:
         command:
             docker:
-                image: aquasec/trivy:0.32.0
+                image: aquasec/trivy:0.32.0@sha256:973d0df16189c229757aa8e81d48d112123e832d576acf5c02c4cb753451608a
                 command: fs --format=cyclonedx --cache-dir=/tmp/trivy/ /app
                 workdir: /app
         format: cyclonedx


### PR DESCRIPTION
```
COSIGN_EXPERIMENTAL=1 cosign verify aquasec/trivy:0.32.0

docker run --rm -ti aquasec/trivy:0.32.0@sha256:973d0df16189c229757aa8e81d48d112123e832d576acf5c02c4cb753451608a
```