### PR TITLE
brakeman - add --force flag

### DIFF
--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -12,7 +12,7 @@ steps:
       command:
         docker:
           image: presidentbeef/brakeman:latest@sha256:7416e4cf46131d5f920be496485d30d55a9b9f00acec28847ae1e5f10ac837f4
-          command: --format json --quiet --no-pager --no-exit-on-warn --no-exit-on-error /src
+          command: --format json --quiet --no-pager --no-exit-on-warn --no-exit-on-error --force /src
           workdir: /src
       format: sarif
       post-processor:

--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -6,6 +6,7 @@ namespace: boostsecurityio/brakeman
 
 config:
   support_diff_scan: true
+  equire_full_repo: true
 
 steps:
   - scan:

--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -6,7 +6,7 @@ namespace: boostsecurityio/brakeman
 
 config:
   support_diff_scan: true
-  equire_full_repo: true
+  require_full_repo: true
 
 steps:
   - scan:


### PR DESCRIPTION
This forces scan even if ./app is not found

See logs here
https://github.com/boost-entropy-ruby/WhatWeb/actions/runs/3246689816/jobs/5325734062#step:3:34

I've tested by pointing the local CLI towards this branch

I have also opened an equivalent PR in `scanner-testing`

Drive-by: add `require_full_repo`

# Before
```
poetry run boost scan repo --offline --path $HOME/sandbox/WhatWeb/ --registry-module boostsecurityio/brakeman
21:14:04 [INFO] boost.app: initializing scanner 1.0.0
21:14:05 [INFO] boost.app: preparing repository
21:14:07 [INFO] boost.app: configuring scanners
21:14:09 [INFO] boost.app: starting scanner for HEAD
21:14:10 [ERROR] boost.app: command 'docker start --attach b83cb8f49867eaba0d063f1...' exited with non-zero exit status: 4
21:14:10 [ERROR] boost.app:   Please supply the path to a Rails application (looking in /src).
21:14:10 [ERROR] boost.app:   Use `--force` to run a scan anyway.
```

# After
```
poetry run boost scan repo --offline --path $HOME/sandbox/WhatWeb/ --registry-module boostsecurityio/brakeman --registry https://github.com/boostsecurityio/scanner-registry#brakeman/force-scan-flag

21:12:10 [INFO] boost.app: initializing scanner 1.0.0
21:12:11 [INFO] boost.app: preparing repository
21:12:13 [INFO] boost.app: configuring scanners
21:12:15 [INFO] boost.app: starting scanner for HEAD
21:12:28 [INFO] boost.app: processing scan results
21:12:28 [INFO] boost.app: uploading scan results
{
 .... (snip big SARIF)
```