### PR TITLE
trivy-image: default flag value fix

### DIFF
--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -50,7 +50,7 @@ steps:
       command:
         environment:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
-          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:--ignore-unfixed}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
         run: |
             $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} --format json --security-checks vuln \
               --quiet ${BOOST_IMAGE_NAME}


### PR DESCRIPTION
```
unset TRIVY_ADDITIONAL_ARGS
echo "${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}"
> --ignore-unfixed
export TRIVY_ADDITIONAL_ARGS="bla"
echo "${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}" 
> bla
```