### PR TITLE
gosec - fix rule mapping and update Docker

### DIFF
--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -11,6 +11,13 @@ config:
   support_diff_scan: true
 
 
+setup:
+  - name: Install post-processing dependency
+    run: |
+      curl -fsSL -O "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
+      echo "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  jq-linux64" | sha256sum --check
+      chmod +x jq-linux64
+
 steps:
   - scan:
       command:
@@ -22,4 +29,4 @@ steps:
             HOME: /tmp/gosec
       format: sarif
       post-processor:
-        run: jq 'walk(if type == "object" and has("id") and has("name") then del(.name) else . end)'
+        run: $SETUP_PATH/jq-linux64 'walk(if type == "object" and has("id") and has("name") then del(.name) else . end)'

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -15,7 +15,7 @@ steps:
   - scan:
       command:
         docker:
-          image: securego/gosec:2.13.1@sha256:a75c847c720d9f6a8bf37e435259a79e10414eb65577729938c956365a5baba4
+          image: securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213
           command: -fmt sarif -no-fail -track-suppressions .
           workdir: /app
           environment:

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -21,3 +21,5 @@ steps:
           environment:
             HOME: /tmp/gosec
       format: sarif
+      post-processor:
+        run: jq 'walk(if type == "object" and has("id") and has("name") then del(.name) else . end)'


### PR DESCRIPTION
- To keep mapping simple, we still need to strip the rule.name, otherwise the SARIF contains a CWE text and is not one to one
- Update gosec's Docker image to bring upstream bugfix which was producing bad SARIF in some cases.

<img width="608" alt="image" src="https://user-images.githubusercontent.com/76956526/196827981-ae7a8f9a-4edd-4651-8f6f-48d89044d7bb.png">

Tested here https://github.com/boost-sandbox/intentionally-vulnerable-golang-project/blob/master/.github/workflows/boost.yml#L34
On dev `sandbox` account

-----

```
cosign verify --key https://raw.githubusercontent.com/securego/gosec/26f10e0a7ab6e0bfb561af1757e17243edaf93ec/cosign.pub securego/gosec:2.14.0

Verification for index.docker.io/securego/gosec:2.14.0 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key

[{"critical":{"identity":{"docker-reference":"index.docker.io/securego/gosec"},"image":{"docker-manifest-digest":"sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213"},"type":"cosign container image signature"},"optional":null}]
```