### PR TITLE
gitleaks: include all files

### DIFF
--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -6,6 +6,8 @@ namespace: boostsecurityio/gitleaks
 
 config:
   support_diff_scan: true
+  include_files:
+    - '*'
 
 steps:
   - scan:


### PR DESCRIPTION
To enable secret scanning using GitLeaks, the module should be able to report findings on all files in the repository. If that causes noise, GitLeaks can be configured to avoid certain paths https://github.com/zricethezav/gitleaks#configuration