### PR TITLE
Fix typo

### DIFF
--- a/scanners/boostsecurityio/native-scanner/rules.yaml
+++ b/scanners/boostsecurityio/native-scanner/rules.yaml
@@ -1043,7 +1043,7 @@ rules:
     categories:
       - ALL
       - supply-chain
-      - supply-chain-missing-artifact-integrity-verifification
+      - supply-chain-missing-artifact-integrity-verification
       - boost-baseline
       - boost-hardened
     description: Checks for binary / executable artifacts (ex. *.jar, *.class, *.so,


### PR DESCRIPTION
Fixed typo, which got caught by the action before uploading

```
Uploading rules "default" "Boost Native Scanner"...
ERROR: Unable to upload rules-db: Unable to update rule due to missing category: supply-chain-missing-artifact-integrity-verifification
```