### PR TITLE
Add initial bundler-audit module

### DIFF
--- a/scanners/boostsecurityio/bundler-audit/README.md
+++ b/scanners/boostsecurityio/bundler-audit/README.md
@@ -1,0 +1,7 @@
+# bundler-audit
+
+## Environment variables
+
+### `GEMFILE_LOCK`
+Path to a custom Gemfile.lock file.
+

--- a/scanners/boostsecurityio/bundler-audit/module.yaml
+++ b/scanners/boostsecurityio/bundler-audit/module.yaml
@@ -1,0 +1,35 @@
+api_version: 1.0
+
+
+id: boostsecurityio/bundler-audit
+name: Boost bundler-audit Scanner
+namespace: boostsecurityio/bundler-audit
+
+
+config:
+  support_diff_scan: true
+  include_files:
+    - Gemfile
+    - ${GEMFILE_LOCK:-Gemfile.lock}
+
+steps:
+  - scan:
+      command:
+        docker:
+          image: ruby:3.1.2@sha256:933ec5cdaeae085292f00f69fd923f680f9d5a82959db74687cbbbd403b85a19
+          command: |
+            bash -c 'touch Gemfile &&
+                     gem install --silent bundler-audit -v "0.9.1" &&
+                     (bundler-audit check --gemfile-lock="$GEMFILE_LOCK" --quiet --update --format json /src || true)'
+          workdir: /src
+          environment:
+            HOME: /tmp
+            GEMFILE_LOCK: ${GEMFILE_LOCK:-Gemfile.lock}
+      format: sarif
+      post-processor:
+        docker:
+            image: public.ecr.aws/boostsecurityio/boost-scanner-bundler-audit:ee8f772@sha256:9d24effc02c96b42ccadaffd886ba5e994efea09b5740dabeb124fe915f406e9
+            command: process
+            environment:
+                GEMFILE_LOCK: ${GEMFILE_LOCK:-Gemfile.lock}
+                PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/bundler-audit/rules.yaml
+++ b/scanners/boostsecurityio/bundler-audit/rules.yaml
@@ -1,0 +1,53 @@
+rules:
+  cve-unknown:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Vulnerability of Unknown Risk
+    name: cve-unknown
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Vulnerability of Unknown Risk
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-low:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Low Risk Vulnerability
+    name: cve-low
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Low Risk Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-moderate:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Medium Risk Vulnerability
+    name: cve-moderate
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Medium Risk Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-high:
+    categories:
+      - ALL
+      - boost-baseline
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a High Risk Vulnerability
+    name: cve-high
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a High Risk Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-critical:
+    categories:
+      - ALL
+      - boost-baseline
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Critical Vulnerability
+    name: cve-critical
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Critical Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db


### PR DESCRIPTION
Add a module to run bundler-audit.
 
There were no image available on hand and bundler-audit wasn't too great to fit into a module.
- The exit code is hard coded to 1 if there are findings. 
- Bundler's lockfile parser implicitly depends on the presence in the cwd of a file named `Gemfile` to parse `Gemfile.lock`, even if it doesn't use it or if a custom lockfile path is used.

 I'll improve forward the way bundler-audit runs when I have a usable Docker image.   
