### PR TITLE
Normalize module names and force sync of all rules.yaml

### DIFF
--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/brakeman
-name: Boostsecurity Brakeman Scanner
+name: BoostSecurity Brakeman
 namespace: boostsecurityio/brakeman
 
 config:

--- a/scanners/boostsecurityio/brakeman/rules.yaml
+++ b/scanners/boostsecurityio/brakeman/rules.yaml
@@ -360,3 +360,4 @@ rules:
     pretty_name: CWE-295 - Improper Certificate Validation
     description: The code does not validate, or incorrectly validates, a certificate.
     ref: https://cwe.mitre.org/data/definitions/295.html
+

--- a/scanners/boostsecurityio/bundler-audit/module.yaml
+++ b/scanners/boostsecurityio/bundler-audit/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/bundler-audit
-name: Boost bundler-audit Scanner
+name: BoostSecurity bundler-audit
 namespace: boostsecurityio/bundler-audit
 
 

--- a/scanners/boostsecurityio/bundler-audit/rules.yaml
+++ b/scanners/boostsecurityio/bundler-audit/rules.yaml
@@ -56,3 +56,4 @@ rules:
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
     ref: https://nvd.nist.gov/vuln-metrics/cvss
+

--- a/scanners/boostsecurityio/checkov/module.yaml
+++ b/scanners/boostsecurityio/checkov/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/checkov
-name: Boostsecurity Checkov Scanner
+name: BoostSecurity Checkov
 namespace: boostsecurityio/checkov
 
 config:

--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/codeql
-name: Boost CodeQL Scanner
+name: BoostSecurity CodeQL
 namespace: boostsecurityio/codeql
 
 config:

--- a/scanners/boostsecurityio/codeql/rules.yaml
+++ b/scanners/boostsecurityio/codeql/rules.yaml
@@ -579,3 +579,4 @@ rules:
     pretty_name: CWE-UNKNOWN - Original rule did not map to a known CWE rule
     description: The original rule could not be map to a CWE rule
     ref: https://codeql.github.com/codeql-query-help/
+

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/gitleaks
-name: Boost GitLeaks Scanner
+name: BoostSecurity Gitleaks
 namespace: boostsecurityio/gitleaks
 
 config:

--- a/scanners/boostsecurityio/gitleaks/rules.yaml
+++ b/scanners/boostsecurityio/gitleaks/rules.yaml
@@ -14,3 +14,4 @@ rules:
       - cwe-200
       - cwe-798
       - cwe-522
+

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/gosec
-name: Boostsecurity GoSec Scanner
+name: BoostSecurity gosec
 namespace: boostsecurityio/gosec
 
 

--- a/scanners/boostsecurityio/gosec/rules.yaml
+++ b/scanners/boostsecurityio/gosec/rules.yaml
@@ -115,7 +115,7 @@ rules:
   G109:
     categories:
       - ALL
-      - cwe-190
+      - cwe-119
       - boost-hardened
     group: top10-insecure-design
     name: G109

--- a/scanners/boostsecurityio/nancy/module.yaml
+++ b/scanners/boostsecurityio/nancy/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/nancy
-name: Boost Nancy Scanner
+name: BoostSecurity nancy
 namespace: boostsecurityio/nancy
 
 

--- a/scanners/boostsecurityio/nancy/rules.yaml
+++ b/scanners/boostsecurityio/nancy/rules.yaml
@@ -56,3 +56,4 @@ rules:
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
     ref: https://nvd.nist.gov/vuln-metrics/cvss
+

--- a/scanners/boostsecurityio/native-scanner/module.yaml
+++ b/scanners/boostsecurityio/native-scanner/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: scanner
-name: Boost Native Scanner
+name: BoostSecurity Native Scanner
 namespace: default
 
 

--- a/scanners/boostsecurityio/native-scanner/rules.yaml
+++ b/scanners/boostsecurityio/native-scanner/rules.yaml
@@ -2051,3 +2051,4 @@ rules:
     name: wildcard-in-system-call
     pretty_name: Wildcard In System Call
     ref: "{BOOSTSEC_DOC_BASE_URL}/rules/code-wildcard-in-system-call.html"
+

--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/npm-audit
-name: Boost npm audit Scanner
+name: BoostSecurity npm-audit
 namespace: boostsecurityio/npm-audit
 
 

--- a/scanners/boostsecurityio/npm-audit/rules.yaml
+++ b/scanners/boostsecurityio/npm-audit/rules.yaml
@@ -56,3 +56,4 @@ rules:
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
     ref: https://nvd.nist.gov/vuln-metrics/cvss
+

--- a/scanners/boostsecurityio/safety/module.yaml
+++ b/scanners/boostsecurityio/safety/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/safety
-name: Boost Safety Scanner
+name: BoostSecurity Safety
 namespace: boostsecurityio/safety
 
 

--- a/scanners/boostsecurityio/safety/rules.yaml
+++ b/scanners/boostsecurityio/safety/rules.yaml
@@ -56,3 +56,4 @@ rules:
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
     ref: https://nvd.nist.gov/vuln-metrics/cvss
+

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/semgrep
-name: Boostsecurity Semgrep Scanner
+name: BoostSecurity semgrep
 namespace: boostsecurityio/semgrep
 
 config:

--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -542,3 +542,4 @@ rules:
     pretty_name: CWE-UNKNOWN - Original rule did not map to a known CWE rule
     description: The original rule could not be map to a CWE rule
     ref: https://github.com/returntocorp/semgrep-rules/
+

--- a/scanners/boostsecurityio/snyk-test/module.yaml
+++ b/scanners/boostsecurityio/snyk-test/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/snyk-test
-name: Boostsecurity Snyk Scanner
+name: BoostSecurity Snyk SCA
 namespace: boostsecurityio/snyk-test
 
 

--- a/scanners/boostsecurityio/snyk-test/rules.yaml
+++ b/scanners/boostsecurityio/snyk-test/rules.yaml
@@ -56,3 +56,4 @@ rules:
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
     ref: https://nvd.nist.gov/vuln-metrics/cvss
+

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/trivy-image
-name: Boostsecurity Trivy Image Scanner
+name: BoostSecurity Trivy (Image scanning)
 namespace: boostsecurityio/trivy-image
 
 
@@ -12,7 +12,7 @@ config:
 
 
 setup:
-  - name: download trivy
+  - name: download snyk-cli
     environment:
       VERSION: 0.32.1
     run: |
@@ -57,7 +57,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:63d4980@sha256:4f6b20be339cfc31b38b6bdf569483a1afef73ec91a968ca6485ae71e48e4ab9
+          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:24f6e4a@sha256:6542680d8321b12758172c97cce27ada5677bd8301b326fc4c68bce9ccdcea63
           command: process
           environment:
             PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/trivy-sbom-image
-name: Boostsecurity Trivy SBOM Image Scanner
+name: BoostSecurity Trivy (Image SBOM)
 namespace: boostsecurityio/trivy-sbom-image
 
 

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/trivy-sbom
-name: Boostsecurity Trivy SBOM
+name: BoostSecurity Trivy (FS SBOM)
 namespace: boostsecurityio/trivy-sbom
 
 


### PR DESCRIPTION
- Normalize module names
- Force sync of all rules.yaml (with extra whitespace) --- this is a hack until we stop doing differential push which is creating more problems than having advantage for now
- Drive-by fix up CWE-190 -> CWE-119 (error in previous run)