### PR TITLE
BST-3366 Adds CWE mapping to semgrep.

### DIFF
--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -241,6 +241,19 @@ rules:
     description: The use of a broken or risky cryptographic algorithm is an unnecessary
       risk that may result in the exposure of sensitive information.
     ref: https://github.com/returntocorp/semgrep-rules/
+  CWE-328:
+    categories:
+    - ALL
+    - cwe-328
+    - boost-baseline
+    - boost-hardened
+    - owasp-top-10
+    group: top10-crypto-failures
+    name: CWE-328
+    pretty_name: CWE-328 - Use of Weak Hash
+    description: The use of a weak cryptographic algorithm is an unnecessary
+      risk that may result in the exposure of sensitive information.
+    ref: https://github.com/returntocorp/semgrep-rules/
   CWE-345:
     categories:
     - ALL


### PR DESCRIPTION
The CWE missing and impacting Coupa:
CWE-328 and CWE-1333.
this adds CWE-328