### PR TITLE
BST-3370 Adds CWE-1333 in semgrep rules db.

### DIFF
--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -670,9 +670,6 @@ rules:
     categories:
     - ALL
     - cwe-1333
-    - boost-baseline
-    - boost-hardened
-    - owasp-top-10
     group: top10-insecure-design
     name: CWE-1333
     pretty_name: CWE-1333 - Inefficient Regular Expression Complexity

--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -666,6 +666,18 @@ rules:
       and executes the code without sufficiently verifying the origin and integrity
       of the code.
     ref: https://github.com/returntocorp/semgrep-rules/
+  CWE-1333:
+    categories:
+    - ALL
+    - cwe-1333
+    - boost-baseline
+    - boost-hardened
+    - owasp-top-10
+    group: top10-insecure-design
+    name: CWE-1333
+    pretty_name: CWE-1333 - Inefficient Regular Expression Complexity
+    description: The product uses a regular expression with an inefficient, possibly exponential worst-case computational complexity that consumes excessive CPU cycles.
+    ref: https://github.com/returntocorp/semgrep-rules/
   CWE-UNKNOWN:
     categories:
     - ALL


### PR DESCRIPTION
semgrep rules db is missing support for CWE-1333. The PR adds that rule.
There is a dependency on the rules-management PR https://github.com/boostsecurityio/boostsec-rules-management/pull/41 for the missing label in rules management.