### PR TITLE
Deploying latest trivy-image main branch on DEV

### DIFF
--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -57,7 +57,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:24f6e4a@sha256:6542680d8321b12758172c97cce27ada5677bd8301b326fc4c68bce9ccdcea63
+          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:49401ca@sha256:6fc745ec658d425144c3e18063ed8d4c0361cd7f54ddbffce93bbc99b782c40f
           command: process
           environment:
             PYTHONIOENCODING: utf-8


### PR DESCRIPTION
## trivy-image
- https://github.com/boostsecurityio/boostsec-scanner-trivy/commit/d829d1c8c412556222331b0550e26d4d547ee37d `BST-2915 Upgrade poetry, flake8, mypy (#12)`
- https://github.com/boostsecurityio/boostsec-scanner-trivy/commit/63d4980e0aefd170bce19b88cb63be5bf5b11b19 `BST-3207 Aligning severity to the standard SCA mapping (#13)`
- https://github.com/boostsecurityio/boostsec-scanner-trivy/commit/49401ca3fa20744bc9a80af2d462d04c816f2650 `BST-2931 Cruft upgrade: Python 3.10 (#14)`