### PR TITLE
Deploying latest safety, nancy, npm-audit main branch on DEV

### DIFF
--- a/scanners/boostsecurityio/nancy/module.yaml
+++ b/scanners/boostsecurityio/nancy/module.yaml
@@ -64,7 +64,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-converter-sca:9016a18@sha256:ad25d4b7da5f159a91e0c05322206e08d62919b4c38681dd8dd0592f2f4f2e75
+            image: public.ecr.aws/boostsecurityio/boost-converter-sca:6e4b6c1@sha256:417c90b672b016b01dac84a4cf24d3a042503b6ddcfd1ba22ebd24d229f78883
             command: process --scanner nancy
             environment:
                 PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -25,7 +25,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-converter-sca:335f358@sha256:a59f3ce62d5fabacb9cefd3fdd92862f07f47f3956514aac4c5d78ce7901f275
+            image: public.ecr.aws/boostsecurityio/boost-converter-sca:6e4b6c1@sha256:417c90b672b016b01dac84a4cf24d3a042503b6ddcfd1ba22ebd24d229f78883
             command: |
               process --scanner npm-audit
             environment:

--- a/scanners/boostsecurityio/safety/module.yaml
+++ b/scanners/boostsecurityio/safety/module.yaml
@@ -26,7 +26,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-converter-sca:935a7ce@sha256:140522c140e267b91bca1ec08cc24d400dfb9075a1c40d2f34a34722152cedcf
+            image: public.ecr.aws/boostsecurityio/boost-converter-sca:6e4b6c1@sha256:417c90b672b016b01dac84a4cf24d3a042503b6ddcfd1ba22ebd24d229f78883
             command: |
               process --scanner safety
             environment:


### PR DESCRIPTION
## nancy
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/aa6bcbe3f3fe62839657019f6daa939d38bec3bf `BST-2915 Upgrade poetry, flake8, mypy (#10)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/ca8a40dda47f3e5c92b71d6bf14025ab179987e1 `Upgrade to latest base image 1.0.19 (#11)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/6e4b6c1a2d1147c0ea49e847608ba8f829caa052 `BST-2931 Cruft upgrade: Python 3.10 (#12)`

## safety
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/9016a1889ceab9011a0b4e1f391ce3c8b5da3d1d `nancy: remove ecosystem from package name (#9)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/aa6bcbe3f3fe62839657019f6daa939d38bec3bf `BST-2915 Upgrade poetry, flake8, mypy (#10)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/ca8a40dda47f3e5c92b71d6bf14025ab179987e1 `Upgrade to latest base image 1.0.19 (#11)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/6e4b6c1a2d1147c0ea49e847608ba8f829caa052 `BST-2931 Cruft upgrade: Python 3.10 (#12)`

## npm-audit
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/439762ac1286d2bc402b24c0ec87c1e09101e412 `Add report processing for Safety (#5)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/136ae7fa03bccf8940b26f9c31e9c9c8d8376136 `Add report processing for Nancy (#7)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/935a7ce72a3132fa2d97f109a26946773b56c177 `Downcase affected_packages dict keys (#8)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/9016a1889ceab9011a0b4e1f391ce3c8b5da3d1d `nancy: remove ecosystem from package name (#9)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/aa6bcbe3f3fe62839657019f6daa939d38bec3bf `BST-2915 Upgrade poetry, flake8, mypy (#10)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/ca8a40dda47f3e5c92b71d6bf14025ab179987e1 `Upgrade to latest base image 1.0.19 (#11)`
- https://github.com/boostsecurityio/boostsec-converter-sca/commit/6e4b6c1a2d1147c0ea49e847608ba8f829caa052 `BST-2931 Cruft upgrade: Python 3.10 (#12)`