### PR TITLE
Deploying latest gitleaks main branch on DEV

### DIFF
--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -21,4 +21,4 @@ steps:
       post-processor:
         docker:
           command: process
-          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:e5b6dd4@sha256:17ad7652bc7e72bb538551e7c7afbd430c1e3240561753b4747edf08972107bb
+          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:da88408@sha256:600b811608386641ab622c25cc9df76b3d69bc1cfe845d5061a2e55247304c36


### PR DESCRIPTION
## gitleaks
- https://github.com/boostsecurityio/boostsec-scanner-gitleaks/commit/402d6643822d46c03420097a295c0d0e16a77add `Run cruft upgrade - SBOM Signing (#4)`
- https://github.com/boostsecurityio/boostsec-scanner-gitleaks/commit/4398b4cc38447dd0dd881c81a3dc7b685b8f8c5a `BST-2915 Upgrade poetry, flake8, mypy (#5)`
- https://github.com/boostsecurityio/boostsec-scanner-gitleaks/commit/4e8555e86ecfdcf24630c6bd67484a6753e0353d `Upgrade to latest base image 1.0.19 (#6)`
- https://github.com/boostsecurityio/boostsec-scanner-gitleaks/commit/da8840839b3fb85630a68c118b81cf056307efdb `BST-2931 Cruft upgrade: Python 3.10 (#7)`