### PR TITLE
Deploying latest trivy-sbom-image main branch on DEV

### DIFF
--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -54,7 +54,7 @@ steps:
       format: cyclonedx
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy-sbom:1a2887c@sha256:9ae707a3369b78d972c75ff552c2cc5b7f25c813549437adbab953e011fe31da
+          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy-sbom:2077b09@sha256:9acea8e0566becbbf19a51b7de326cda23d124254091f38cf5e2132f298a1301
           command: process
           environment:
             PYTHONIOENCODING: utf-8


### PR DESCRIPTION
## trivy-sbom-image
- https://github.com/boostsecurityio/boostsec-scanner-trivy-sbom/commit/75fa5d92ac935d6156b69958e08819eb9ed608fc `BST-2915 Upgrade poetry, flake8, mypy (#3)`
- https://github.com/boostsecurityio/boostsec-scanner-trivy-sbom/commit/8f6f058f31f512dc7510365c0a5dc2d18189ece9 `Upgrade to latest base image 1.0.19 (#4)`
- https://github.com/boostsecurityio/boostsec-scanner-trivy-sbom/commit/2077b09e1bd96c0db3b558a1c6b80a69a2dedc80 `BST-2931 Cruft upgrade: Python 3.10 (#5)`